### PR TITLE
[fix] execute callback after building is complete

### DIFF
--- a/lib/buildbot.js
+++ b/lib/buildbot.js
@@ -224,7 +224,7 @@ console.error('FIRING FINALIZATION', err);
                   .pipe(tar.Pack({ noProprietary: true }).on('error', finish))
                   .pipe(zlib.Gzip().on('error', finish))
                   .pipe(new BufferedStream().on('error', finish)).on('end', finish);
-                return self.perform('build.output', null, description, stream, function(){});
+                return self.perform('build.output', null, description, stream, callback);
               });
             });
           })


### PR DESCRIPTION
@bmeck is this sane? It seems to hang when the callback isn't executed
