### PR TITLE
Various updates to ensure this can run inside nodejitsu/nodejitsu tests

### DIFF
--- a/bin/localfiles
+++ b/bin/localfiles
@@ -3,7 +3,6 @@
 var http = require('http'),
     fs = require('fs'),
     path = require('path'),
-
     argv = require('optimist').argv;
 
 if (!argv.c) {
@@ -11,12 +10,13 @@ if (!argv.c) {
   process.exit(1);
 }
 
-var config = require(path.join(process.env.PWD, argv.c.replace('.json', '')));
-var basePath = config.localfiles.path;
-http.createServer(function(req, res) {
+var config = require(path.join(process.env.PWD, argv.c.replace('.json', ''))),
+    basePath = config.localfiles.path;
+
+http.createServer(function (req, res) {
   var file = path.join(basePath, req.url.replace('/', ''));
   console.log('file', file);
-  fs.stat(file, function(err) {
+  fs.stat(file, function (err) {
     if (err) {
       res.writeHead(404);
       return res.end('not found');
@@ -25,6 +25,7 @@ http.createServer(function(req, res) {
     res.writeHead(200, {
       'Content-type' : 'application/tar+gzip'
     });
+    
     fs.createReadStream(file).pipe(res);
   });
 }).listen(config.localfiles.port);

--- a/bin/module-foundry
+++ b/bin/module-foundry
@@ -11,41 +11,12 @@
 // - module cache
 // - more error checks
 //
-var flatiron = require('flatiron');
-var Understudy = require('understudy').Understudy;
-var argv = require('optimist').argv;
-var configFile = argv.c ? require('path').join(__dirname, '..', 'config',  argv.c) : 'config.json';
 
-var os = require('os');
-var app = Understudy.call(flatiron.app);
-app.config.argv().file(configFile).env().defaults({
-   directories: {
-      tmp: __dirname + '/../tmp'
-   },
-   node: {
-    gypdir: process.env.HOME + '/.node-gyp',
-    versions: [process.version.slice(1)]
-   },
-   spawning: {
-    platform: os.platform(),
-    arch: os.arch(),
-    env: {
-      npm_config_production: 'true'
-    },
-    user: 'nobody',
-    group: 'nobody'
-   },
-   defaults: {
-     build: {
-       version: '0.8.x'
-     }
-   }
+var argv = require('optimist').argv,
+    foundry = require('../lib');
+
+foundry.start({
+  configFile: argv.c 
+    ? require('path').join(__dirname, '..', 'config',  argv.c) 
+    : 'config.json'
 });
-//
-// Monitor and Repository support
-//
-app.use(require('../lib/plugins/pluggable'));
-app.use(require('../lib/plugins/servers'));
-app.use(require('../lib/plugins/http'));
-require('../lib/routes')(app, app.config.get('routes'));
-app.init();

--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -20,10 +20,8 @@
   },
   "rackspace": {
     "cloudfiles": {
-      "auth": {
-        "username": "x",
-        "apiKey": "x"
-      }
+      "username": "x",
+      "apiKey": "x"
     },
     "appsContainer": "nodejitsu-apps",
     "keysContainer": "ssh-keys",

--- a/lib/buildbot.js
+++ b/lib/buildbot.js
@@ -9,7 +9,7 @@ var path = require('path'),
     fstream = require('fstream'),
     merge = require('merge-recursive'),
     semver = require('semver'),
-    tar = require('tar')
+    tar = require('tar'),
     uidNumber = require('uid-number'),
     Understudy = require('understudy').Understudy;
 

--- a/lib/buildbot.js
+++ b/lib/buildbot.js
@@ -205,6 +205,7 @@ BuildBot.prototype.spawnNPM = function spawnNPM(description, callback) {
         // Package the result
         //
         var pkgJSON = moduledir + '/package.json';
+
         async.parallel([
           fs.writeFile.bind(fs, builddir + '/spawnOptions.json', JSON.stringify(spawnOptions)),
           fs.writeFile.bind(fs, builddir + '/description.json', JSON.stringify(description))
@@ -215,6 +216,10 @@ BuildBot.prototype.spawnNPM = function spawnNPM(description, callback) {
           }
 
           fs.readdir(moduledir + '/node_modules', function (err, files) {
+            if (err && err.code === 'ENOENT') {
+              files = [];
+            }
+
             return fs.readFile(pkgJSON, function (err, body) {
               if (err) {
                 return callback(err);

--- a/lib/buildbot.js
+++ b/lib/buildbot.js
@@ -1,21 +1,22 @@
-var path = require('path');
-var Understudy = require('understudy').Understudy;
-var checkout = require('checkout');
-var tar = require('tar');
-var async = require('async');
-var chownr = require('chownr');
-var zlib = require('zlib');
-var fs = require('fs');
-var spawn = require('child_process').spawn;
-var fstream = require("fstream");
-var uidNumber = require('uid-number');
-var merge = require('merge-recursive');
-var semver = require('semver');
-var BufferedStream = require('morestreams').BufferedStream;
+var path = require('path'),
+    zlib = require('zlib'),
+    fs = require('fs'),
+    spawn = require('child_process').spawn,
+    async = require('async'),
+    BufferedStream = require('morestreams').BufferedStream,
+    checkout = require('checkout'),
+    chownr = require('chownr'),
+    fstream = require('fstream'),
+    merge = require('merge-recursive'),
+    semver = require('semver'),
+    tar = require('tar')
+    uidNumber = require('uid-number'),
+    Understudy = require('understudy').Understudy;
+
 //
 // Extensible build bot
 //
-function BuildBot(options) {
+var BuildBot = module.exports = function BuildBot(options) {
   Understudy.call(this);
   options = options || {};
   options.versions = options.versions || [process.version.slice(1)];
@@ -23,8 +24,7 @@ function BuildBot(options) {
   this.versions = options.versions;
   this.defaults = options.defaults;
   return this;
-}
-module.exports = BuildBot;
+};
 
 //
 // Perform the build
@@ -44,105 +44,112 @@ module.exports = BuildBot;
 //
 
 BuildBot.prototype.build = function build(description, callback/* err, tar-stream */) {
-console.error(description)
+  console.error(description);
   var self = this;
+
   //
   // Allow configuration
   //
   async.waterfall([
-      self.perform.bind(self, 'build.configure', null, description),
-      function (description, callback) {
-        async.parallel([
-          fs.mkdir.bind(fs, description.repository.destination + '/build'),
-          fs.mkdir.bind(fs, description.repository.destination + '/npm-cache'),
-          fs.mkdir.bind(fs, description.repository.destination + '/tmp')
-        ], function (err) {
-          callback(err, description);
-        })
-      },
-      self.perform.bind(self, 'repository.configure', null),
-      function (description, callback) {
-        var repository = Object.create(description.repository);
-        repository.destination += '/build';
-        checkout(repository, function (err) {
-          callback(err, description);
+    self.perform.bind(self, 'build.configure', null, description),
+    function (description, callback) {
+      async.parallel([
+        fs.mkdir.bind(fs, description.repository.destination + '/build'),
+        fs.mkdir.bind(fs, description.repository.destination + '/npm-cache'),
+        fs.mkdir.bind(fs, description.repository.destination + '/tmp')
+      ], function (err) {
+        callback(err, description);
+      });
+    },
+    self.perform.bind(self, 'repository.configure', null),
+    function (description, callback) {
+      var repository = Object.create(description.repository);
+      repository.destination += '/build';
+      checkout(repository, function (err) {
+        callback(err, description);
+      });
+    },
+    function (description, callback) {
+      var dir = description.repository.destination,
+          pkg = path.join(dir, 'build', 'package', 'package.json');
+
+      fs.readFile(pkg, function (err, contents) {
+        if (err) {
+          return callback(err, null);
+        }
+
+        var pkgJSON = JSON.parse(contents);
+        if (!description.version) {
+          var engines = pkgJSON.engine || pkgJSON.engines;
+          if (typeof engines === 'string') {
+            description.version = semver.maxSatisfying(self.versions, engines);
+          }
+          else if (engines && engines.node) {
+            description.version = semver.maxSatisfying(self.versions, engines.node);
+          }
+          else {
+            description.version = semver.maxSatisfying(self.versions, self.defaults.version || process.version.slice(1));
+          }
+        }
+
+        if (!description.version) {
+          return callback(new Error('No matching versions found'));
+        }
+
+        console.error('installing with version', description.version)
+        merge.recursive(description, {
+          env: {
+            PATH: process.env.PATH,
+            HOME: dir,
+            ROOT: dir,
+            USER: description.user,
+            LDFLAGS: '-m64',
+            CFLAGS: '-m64',
+            CPPFLAGS: '-m64',
+            CXXFLAGS: '-m64',
+            TMPDIR: dir + '/tmp',
+            npm_config_user: description.user,
+            npm_config_arch: description.arch,
+            npm_config_production: true,
+            npm_config_cache: dir + '/npm-cache',
+            npm_config_globalconfig: dir + '/npmglobalrc',
+            npm_config_userconfig: dir + '/npmlocalrc',
+            'npm_config_node-version': description.version,
+            //npm_config_loglevel : 'silly',
+            npm_config_nodedir: process.env.HOME + '/.node-gyp/' + description.version
+          }
         });
-      },
-      function (description, callback) {
-        var dir = description.repository.destination;
-        var pkg = path.join(dir, 'build', 'package', 'package.json');
-        fs.readFile(pkg, function (err, contents) {
+
+        Object.keys(pkgJSON.env || {}).forEach(function (key) {
+          if (!description.env[key]) description.env[key] = pkgJSON.env[key];
+        });
+
+        uidNumber(description.user, description.group, function (err, uid, gid) {
           if (err) {
-            callback(err, null);
-            return;
+            return callback(err);
           }
-          var pkgJSON = JSON.parse(contents);
-          if (!description.version) {
-            var engines = pkgJSON.engine || pkgJSON.engines;
-            if (typeof engines === 'string') {
-              description.version = semver.maxSatisfying(self.versions, engines);
-            }
-            else if (engines && engines.node) {
-              description.version = semver.maxSatisfying(self.versions, engines.node);
-            }
-            else {
-              description.version = semver.maxSatisfying(self.versions, self.defaults.version || process.version.slice(1));
-            }
-          }
-          if (!description.version ) {
-            callback(new Error('No matching versions found'));
-            return;
-          }
-console.error('installing with version', description.version)
-          merge.recursive(description, {
-            env: {
-              PATH : process.env.PATH,
-              HOME : dir,
-              ROOT : dir,
-              USER : description.user,
-              LDFLAGS : '-m64',
-              CFLAGS  : '-m64',
-              CPPFLAGS : '-m64',
-              CXXFLAGS : '-m64',
-              TMPDIR : dir + '/tmp',
-              npm_config_user : description.user,
-              npm_config_arch : description.arch,
-              npm_config_production : true,
-              npm_config_cache : dir+'/npm-cache',
-              npm_config_globalconfig : dir+'/npmglobalrc',
-              npm_config_userconfig : dir+'/npmlocalrc',
-              'npm_config_node-version': description.version,
-              //npm_config_loglevel : 'silly',
-              npm_config_nodedir : process.env.HOME + '/.node-gyp/' + description.version
-            }
-          });
-          Object.keys(pkgJSON.env || {}).forEach(function (key) {
-            if (!description.env[key]) description.env[key] = pkgJSON.env[key];
-          });
-          uidNumber(description.user, description.group, function (err, uid, gid) {
-            if (err) {
-              callback(err);
-              return;
-            }
-            chownr(description.repository.destination, uid, gid, function () {
-              callback(err, description)
-            });
+
+          chownr(description.repository.destination, uid, gid, function () {
+            callback(err, description)
           });
         });
-      },
-      self.spawnNPM.bind(self)
+      });
+    },
+    self.spawnNPM.bind(self)
   ], callback);
 }
 
 BuildBot.prototype.spawnNPM = function spawnNPM(description, callback) {
-  var self = this;
+  var self = this,
+      rootdir = description.repository.destination,
+      builddir = rootdir + '/build',
+      moduledir = builddir + '/package',
+      spawnOptions;
+
   //
   // Default values
   //
-  var rootdir = description.repository.destination;
-  var builddir = rootdir + '/build';
-  var moduledir = builddir + '/package';
-  var spawnOptions = {
+  spawnOptions = {
     options: description.options || [],
     spawnWith: {
       cwd: moduledir
@@ -151,40 +158,49 @@ BuildBot.prototype.spawnNPM = function spawnNPM(description, callback) {
     user: description.user,
     group: description.group
   };
+
   //
   // Allow configuration
   //
   async.waterfall([
     self.perform.bind(self, 'npm.configure', null, spawnOptions),
     function (spawnOptions) {
-      var builder = spawn('sudo', [
-        '-u', spawnOptions.user
-      ].concat(Object.keys(spawnOptions.env || {}).map(function (k) {
-        return k + '=' + description.env[k];
-      })).concat([
-        '--',
-        'npm', 'install',
-      ]).concat(spawnOptions.options || []), {
-        env: spawnOptions.env,
-        cwd: moduledir
-      });
+      var builder = spawn('sudo',
+        ['-u', spawnOptions.user]
+          .concat(Object.keys(spawnOptions.env || {}).map(function (k) {
+            return k + '=' + description.env[k];
+          }))
+          .concat([
+            '--',
+            'npm', 'install',
+          ])
+          .concat(spawnOptions.options || []),
+        {
+          env: spawnOptions.env,
+          cwd: moduledir
+        }
+      );
+
       var logFile = fs.createWriteStream(builddir + '/npm-output.log');
+
       builder.stdout.pipe(logFile);
       builder.stderr.pipe(logFile);
+
       var npmOutput = new BufferedStream();
+
       builder.stdout.pipe(npmOutput);
       builder.stderr.pipe(npmOutput);
       builder.stdout.pipe(process.stdout);
       builder.stderr.pipe(process.stderr);
       builder.on('exit', function (code) {
-console.error('npm.exit', arguments)
+        console.error('npm.exit', arguments)
         if (code !== 0) {
           var err = new Error('npm exited with code ' + code);
           err.stream = npmOutput;
-          callback(err, null);
-          return;
+          return callback(err, null);
         }
         npmOutput = null;
+
         //
         // Package the result
         //
@@ -193,40 +209,53 @@ console.error('npm.exit', arguments)
           fs.writeFile.bind(fs, builddir + '/spawnOptions.json', JSON.stringify(spawnOptions)),
           fs.writeFile.bind(fs, builddir + '/description.json', JSON.stringify(description))
         ], function (err) {
-console.error('FIRING FINALIZATION', err);
+          console.error('FIRING FINALIZATION', err);
           if (err) {
-            callback(err);
-            return;
+            return callback(err);
           }
+
           fs.readdir(moduledir + '/node_modules', function (err, files) {
             return fs.readFile(pkgJSON, function (err, body) {
-              if (err) return callback(err);
+              if (err) {
+                return callback(err);
+              }
+
               var pkg;
-              try {
-                pkg = JSON.parse(body);
-              }
-              catch (e) {
-                return callback(e);
-              }
+
+              try { pkg = JSON.parse(body) }
+              catch (e) { return callback(e) }
+
               pkg.bundledDependencies = files.filter(function (file) {
                 return file !== ".bin";
               });
+
               pkg.env = pkg.env || {};
               pkg.env['npm_config_rebuild_bundle'] = false;
               pkg.env['npm_config_production'] = true;
+
               return fs.writeFile(pkgJSON, JSON.stringify(pkg), function (err) {
-                if (err) return callback(err);
-                var done = false;
-                function finish() {
-                  if (done) return;
-                  done = true;
-                  return callback.apply(this, arguments);
+                if (err) {
+                  return callback(err);
                 }
-                var stream = fstream.Reader({ path: moduledir, type: "Directory", isDirectory: true }).on('error', finish)
-                  .pipe(tar.Pack({ noProprietary: true }).on('error', finish))
+
+                var done = false;
+
+                function finish() {
+                  if (!done) {
+                    done = true;
+                    return callback.apply(this, arguments);
+                  }
+                }
+
+                var stream = fstream.Reader({ path: moduledir, type: "Directory", isDirectory: true })
+                  .on('error', finish)
+                  .pipe(tar.Pack({ noProprietary: true })
+                  .on('error', finish))
                   .pipe(zlib.Gzip().on('error', finish))
-                  .pipe(new BufferedStream().on('error', finish)).on('end', finish);
-                return self.perform('build.output', null, description, stream, function(){});
+                  .pipe(new BufferedStream().on('error', finish))
+                  .on('end', finish);
+
+                return self.perform('build.output', null, description, stream, function () {});
               });
             });
           })
@@ -235,5 +264,5 @@ console.error('FIRING FINALIZATION', err);
       self.perform('npm.wait', builder, function () {});
     }
   ], callback);
-}
+};
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ app.start = function (options, callback) {
     .argv()
     .file(options.configFile)
     .env()
-    .defaults({
+    .defaults(options.defaults || {
       directories: {
         tmp: __dirname + '/../tmp'
       },

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,44 +1,51 @@
 var os = require('os'),
     flatiron = require('flatiron'),
-    Understudy = require('understudy').Understudy
+    Understudy = require('understudy').Understudy;
 
-exports.start = function (options) {
-  var app = Understudy.call(flatiron.app);
-  
-  app.config.argv().file(configFile).env().defaults({
-    directories: {
-      tmp: __dirname + '/../tmp'
-    },
-    node: {
-      gypdir: process.env.HOME + '/.node-gyp',
-      versions: [process.version.slice(1)]
-    },
-    spawning: {
-      platform: os.platform(),
-      arch: os.arch(),
-      env: {
-        npm_config_production: 'true'
+var app = module.exports = Understudy.call(flatiron.app);
+
+app.start = function (options, callback) {
+  options = options || {};
+  callback = callback || function () { };
+
+  app.config
+    .argv()
+    .file(options.configFile)
+    .env()
+    .defaults({
+      directories: {
+        tmp: __dirname + '/../tmp'
       },
-      user: 'nobody',
-      group: 'nobody'
-    },
-    defaults: {
-      build: {
-        version: '0.8.x'
+      node: {
+        gypdir: process.env.HOME + '/.node-gyp',
+        versions: [process.version.slice(1)]
+      },
+      spawning: {
+        platform: os.platform(),
+        arch: os.arch(),
+        env: {
+          npm_config_production: 'true'
+        },
+        user: 'nobody',
+        group: 'nobody'
+      },
+      defaults: {
+        build: {
+          version: '0.8.x'
+        }
       }
-    }
-  });
+    });
 
   //
   // Monitor and Repository support
   //
-  app.use(require('.plugins/pluggable'));
+  app.use(require('./plugins/pluggable'));
   app.use(require('./plugins/servers'));
   app.use(require('./plugins/http'));
   require('./routes')(app, app.config.get('routes'));
-  
+
   //
   // Start the application
   //
-  app.init();
+  app.init(callback);
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,44 @@
+var os = require('os'),
+    flatiron = require('flatiron'),
+    Understudy = require('understudy').Understudy
+
+exports.start = function (options) {
+  var app = Understudy.call(flatiron.app);
+  
+  app.config.argv().file(configFile).env().defaults({
+    directories: {
+      tmp: __dirname + '/../tmp'
+    },
+    node: {
+      gypdir: process.env.HOME + '/.node-gyp',
+      versions: [process.version.slice(1)]
+    },
+    spawning: {
+      platform: os.platform(),
+      arch: os.arch(),
+      env: {
+        npm_config_production: 'true'
+      },
+      user: 'nobody',
+      group: 'nobody'
+    },
+    defaults: {
+      build: {
+        version: '0.8.x'
+      }
+    }
+  });
+
+  //
+  // Monitor and Repository support
+  //
+  app.use(require('.plugins/pluggable'));
+  app.use(require('./plugins/servers'));
+  app.use(require('./plugins/http'));
+  require('./routes')(app, app.config.get('routes'));
+  
+  //
+  // Start the application
+  //
+  app.init();
+};

--- a/lib/plugins/cloudfiles.js
+++ b/lib/plugins/cloudfiles.js
@@ -1,40 +1,48 @@
-var BufferedStream = require('morestreams').BufferedStream;
-var pkgcloud = require('pkgcloud');
+var BufferedStream = require('morestreams').BufferedStream,
+    pkgcloud = require('pkgcloud');
+
+exports.name = 'cloudfiles';
+
 exports.attach = function () {
-   var app = this;
-   var client = pkgcloud.storage.createClient({
-      provider: 'rackspace',
-      username: app.config.get('rackspace:cloudfiles:username'),
-      apiKey: app.config.get('rackspace:cloudfiles:apiKey')
-   });
+  var app = this,
+      client;
 
-   app.before('build.create', function (bot, next) {
-     bot.before('build.output', function (err, description, stream, callback) {
-       if (err || !description.filename) {
-         callback(err, description, stream);
-         return;
-       }
+  client = pkgcloud.storage.createClient({
+    provider: 'rackspace',
+    username: app.config.get('rackspace:cloudfiles:username'),
+    apiKey: app.config.get('rackspace:cloudfiles:apiKey')
+  });
 
-       client.auth(function(err) {
-         if (err) {
-           callback(err, description, stream);
-           return;
-         }
-         var uploadStream = client.upload({
-           remote: description.filename,
-           container: app.config.get('rackspace:snapshotsContainer')
-         });
-         uploadStream.on('error', function (err) {
-console.error('upload error!', err)
-           callback(err, description, stream);
-         });
-         uploadStream.on('end', function () {
-console.error('upload ok!', description.filename)
-            setTimeout(callback.bind(null, null, description, stream), 6 * 1000);
-         });
-         stream.pipe(uploadStream);
-       });
-     });
-     next(bot);
-   });
-}
+  app.before('build.create', function (bot, next) {
+    bot.before('build.output', function (err, description, stream, callback) {
+      if (err || !description.filename) {
+        return callback(err, description, stream);
+      }
+
+      client.auth(function (err) {
+        if (err) {
+          return callback(err, description, stream);
+        }
+
+        var uploadStream = client.upload({
+          remote: description.filename,
+          container: app.config.get('rackspace:snapshotsContainer')
+        });
+
+        uploadStream.on('error', function (err) {
+          console.error('upload error!', err)
+          callback(err, description, stream);
+        });
+
+        uploadStream.on('end', function () {
+          console.error('upload ok!', description.filename)
+          setTimeout(callback.bind(null, null, description, stream), 6 * 1000);
+        });
+
+        stream.pipe(uploadStream);
+      });
+    });
+
+    next(bot);
+  });
+};

--- a/lib/plugins/cloudfiles.js
+++ b/lib/plugins/cloudfiles.js
@@ -4,8 +4,10 @@ exports.attach = function () {
    var app = this;
    var client = pkgcloud.storage.createClient({
       provider: 'rackspace',
-      auth: app.config.get('rackspace:cloudfiles:auth')
+      username: app.config.get('rackspace:cloudfiles:username'),
+      apiKey: app.config.get('rackspace:cloudfiles:apiKey')
    });
+
    app.before('build.create', function (bot, next) {
      bot.before('build.output', function (err, description, stream, callback) {
        if (err || !description.filename) {

--- a/lib/plugins/debug.js
+++ b/lib/plugins/debug.js
@@ -1,7 +1,8 @@
-var net = require('net');
-var repl = require('repl');
-var util = require('util');
-var assert = require('assert');
+var net = require('net'),
+    repl = require('repl'),
+    util = require('util'),
+    assert = require('assert');
+
 //
 // Simple plugin to add a dumb debugging repl
 //
@@ -15,87 +16,97 @@ var assert = require('assert');
 // options.excludeProcess = false
 //
 exports.name = 'debug';
+
 exports.attach = function (options) {
-   options = options || {};
-   options.port = options.port !== null && options.port || 1337;
-   options.columns = options.columns || 80;
-   options.host = options.host || '127.0.0.1';
-   var app = this;
-   net.createServer(function (conn) {
-      //
-      // Check a whitelist of places we are allowed to connect from if specified
-      //
-      var remoteAddress = conn.remoteAddress;
-      if (options.whitelist && !options.whitelist.some(function (whitelisted) {
-         return typeof whitelisted === 'string' ?
-            remoteAddress.address === whitelisted :
-            whitelisted.port === remoteAddress.port && whitelisted.address === remoteAddress.address;
-      })) {
-         conn.destroy();
-         return;
+  var app = this;
+
+  options         = options || {};
+  options.port    = options.port !== null && options.port || 1337;
+  options.columns = options.columns || 80;
+  options.host    = options.host || '127.0.0.1';
+
+  net.createServer(function (conn) {
+    //
+    // Check a whitelist of places we are allowed to connect from if specified
+    //
+    var remoteAddress = conn.remoteAddress;
+
+    if (options.whitelist && !options.whitelist.some(function (whitelisted) {
+      return typeof whitelisted === 'string' ?
+        remoteAddress.address === whitelisted :
+        whitelisted.port === remoteAddress.port && whitelisted.address === remoteAddress.address;
+    })) {
+      conn.destroy();
+      return;
+    }
+
+    remoteAddress = null;
+    conn.columns = options.columns || 80;
+
+    var prompt = repl.start({
+      input: conn,
+      output: conn,
+      terminal: options.terminal,
+      useColors: options.useColors,
+      useGlobal: false
+    });
+
+    prompt.on('exit', function () {
+      conn.end();
+    });
+
+    //
+    // Process can be dangerous but no real alterative that is liked for getting
+    // various data (not going to wrap it)
+    //
+    if (!options.excludeProcess) {
+      prompt.context.process = process;
+    }
+
+    prompt.context.app = app;
+
+    //
+    // Repl should have console forwarded to it rather than printed on server
+    //
+    var times = {};
+    prompt.context.console = {
+      log: function () {
+        conn.write([].slice.apply(arguments).map(util.inspect).join(' ') + '\n');
+      },
+      error: function () {
+        conn.write([].slice.apply(arguments).map(util.inspect).join(' ') + '\n');
+      },
+      warn: function () {
+        conn.write([].slice.apply(arguments).map(util.inspect).join(' ') + '\n');
+      },
+      info: function () {
+        conn.write([].slice.apply(arguments).map(util.inspect).join(' ') + '\n');
+      },
+      dir: function (obj) {
+        conn.write(util.inspect(obj) + '\n');
+      },
+      trace: function () {
+        conn.write(new Error('Trace').stack + '\n');
+      },
+      time: function (id) {
+        times[id] = Date.now();
+      },
+      timeEnd: function (id) {
+        var time = times[id];
+        if (time !== undefined) {
+          conn.write(id + ': ' + (Date.now() - time) + 'ms\n');
+          delete times[id];
+        }
+        else {
+          conn.write(new Error('Error: No such label: '+id).stack + '\n');
+        }
+      },
+      assert: function (cond) {
+        try { assert(cond) }
+        catch (e) { conn.write(e.stack + '\n') }
       }
-      remoteAddress = null;
-      conn.columns = options.columns || 80;
-      var prompt = repl.start({
-         input: conn,
-         output: conn,
-         terminal: options.terminal,
-         useColors: options.useColors,
-         useGlobal: false
-      });
-      prompt.on('exit', function () {
-         conn.end();
-      });
-      //
-      // Process can be dangerous but no real alterative that is liked for getting various data (not going to wrap it)
-      //
-      if (!options.excludeProcess) prompt.context.process = process;
-      prompt.context.app = app;
-      //
-      // Repl should have console forwarded to it rather than printed on server
-      //
-      var times = {};
-      prompt.context.console = {
-         log: function () {
-            conn.write([].slice.apply(arguments).map(util.inspect).join(' ') + '\n');
-         },
-         error: function () {
-            conn.write([].slice.apply(arguments).map(util.inspect).join(' ') + '\n');
-         },
-         warn: function () {
-            conn.write([].slice.apply(arguments).map(util.inspect).join(' ') + '\n');
-         },
-         info: function () {
-            conn.write([].slice.apply(arguments).map(util.inspect).join(' ') + '\n');
-         },
-         dir: function (obj) {
-            conn.write(util.inspect(obj) + '\n');
-         },
-         trace: function () {
-            conn.write(new Error('Trace').stack + '\n');
-         },
-         time: function (id) {
-            times[id] = Date.now();
-         },
-         timeEnd: function (id) {
-            var time = times[id];
-            if (time !== undefined) {
-               conn.write(id + ': ' + (Date.now() - time) + 'ms\n');
-               delete times[id];
-            }
-            else {
-               conn.write(new Error('Error: No such label: '+id).stack + '\n');
-            }
-         },
-         assert: function (cond) {
-            try {
-               assert(cond);
-            }
-            catch (e) {
-               conn.write(e.stack + '\n');
-            }
-         }
-      }
-      prompt = null;
-   }).listen(options.port, options.host);
-}
+    }
+
+    prompt = null;
+  }).listen(options.port, options.host);
+};

--- a/lib/plugins/http.js
+++ b/lib/plugins/http.js
@@ -27,8 +27,10 @@ exports.attach = function () {
   };
 };
 
-exports.init = function () {
-  var app = this;
+exports.init = function (done) {
+  var app = this,
+      listen = { expected: 0, current: 0 },
+      responded = false;
 
   function workflow(req, res) {
     req.buffered = new BufferedStream();
@@ -63,12 +65,30 @@ exports.init = function () {
     res.end();
   }
 
-  if (app.config.get('http')) {
-    app.servers.http.on('request', workflow);
-    app.servers.http.listen(app.config.get('http:port') || 80, app.config.get('http:address') || '::1');
+  function onListen() {
+    if (++listen.current >= listen.expected && !responded) {
+      responded = true;
+      return done();
+    }
   }
+
+  if (app.config.get('http')) {
+    listen.expected++;
+    app.servers.http.on('request', workflow);
+    app.servers.http.listen(
+      app.config.get('http:port') || 80,
+      app.config.get('http:address') || '::1',
+      onListen
+    );
+  }
+
   if (app.config.get('https')) {
+    listen.expected++;
     app.servers.https.on('request', workflow);
-    app.servers.https.listen(app.config.get('https:port') || 443, app.config.get('https:address') || '::1');
+    app.servers.https.listen(
+      app.config.get('https:port') || 443,
+      app.config.get('https:address') || '::1',
+      onListen
+    );
   }
 };

--- a/lib/plugins/http.js
+++ b/lib/plugins/http.js
@@ -1,69 +1,74 @@
-var director = require('director');
-var url = require('url');
-var BufferedStream = require('morestreams').BufferedStream;
+var url = require('url'),
+    director = require('director'),
+    BufferedStream = require('morestreams').BufferedStream;
 
 exports.name = 'http-service';
 
 exports.attach = function () {
-   var app = this;
-   //
-   // Probes
-   //
-   // 1. http.incoming (reject connections / log from here) ->
-   // 2. http.authorization (set req.authorization) ->
-   // 2.1 http.authorized (do things)
-   // 2.1 http.unauthorized (do things)
-   //
-   // Routing
-   //
-   // app.routers.authorized - req.authorized was populated during or before http.authorization
-   // app.routers.unauthorized - req.authorized was not set or no authorized route was found
-   // - will not be used if request is authorized but config.get('authorization:no-fallthrough') is truthy
-   //
-   app.routers = {
-      authorized: new director.http.Router(),
-      unauthorized: new director.http.Router()
-   };
-}
+  var app = this;
+
+  //
+  // Probes
+  //
+  // 1. http.incoming (reject connections / log from here) ->
+  // 2. http.authorization (set req.authorization) ->
+  // 2.1 http.authorized (do things)
+  // 2.1 http.unauthorized (do things)
+  //
+  // Routing
+  //
+  // app.routers.authorized - req.authorized was populated during or before http.authorization
+  // app.routers.unauthorized - req.authorized was not set or no authorized route was found
+  // - will not be used if request is authorized but config.get('authorization:no-fallthrough') is truthy
+  //
+  app.routers = {
+    authorized: new director.http.Router(),
+    unauthorized: new director.http.Router()
+  };
+};
 
 exports.init = function () {
-   function workflow(req, res) {
-      req.buffered = new BufferedStream();
-      req.params = url.parse(req.url, true).query;
-      req.pipe(req.buffered);
-      app.perform('http.incoming', req, res, function getAuthorization(req, res, cleanup) {
-         app.perform('http.authorization', req, res, function routeAuthorization(req, res, cleanup) {
-            if (req.authorization) {
-               app.perform('http.authorized', req, res, handleAuthorized);
-            }
-            else {
-               app.perform('http.unauthorized', req, res, app.config.get('unauthorized:ok') ? handleAuthorized : handleUnauthorized);
-            }
-         });
+  var app = this;
+
+  function workflow(req, res) {
+    req.buffered = new BufferedStream();
+    req.params = url.parse(req.url, true).query;
+    req.pipe(req.buffered);
+    app.perform('http.incoming', req, res, function getAuthorization(req, res, cleanup) {
+      app.perform('http.authorization', req, res, function routeAuthorization(req, res, cleanup) {
+        if (req.authorization) {
+          app.perform('http.authorized', req, res, handleAuthorized);
+        }
+        else {
+          app.perform('http.unauthorized', req, res, app.config.get('unauthorized:ok') ? handleAuthorized : handleUnauthorized);
+        }
       });
-   }
-   
-   var app = this;
-   function handleUnauthorized(req, res, cleanup) {
-      if (app.routers.unauthorized.dispatch(req, res)) return;
-      //
-      // Even if it is a 404, act like it is 403
-      //
-      res.writeHead(403);
-      res.end();
-   }
-   function handleAuthorized(req, res, cleanup) {
-      if (app.routers.authorized.dispatch(req, res)) return;
-      if (app.routers.unauthorized.dispatch(req, res)) return;
-      res.writeHead(404);
-      res.end();
-   }
-   if (app.config.get('http')) {
-      app.servers.http.on('request', workflow);
-      app.servers.http.listen(app.config.get('http:port') || 80, app.config.get('http:address') || '::1');
-   }
-   if (app.config.get('https')) {
-      app.servers.https.on('request', workflow);
-      app.servers.https.listen(app.config.get('https:port') || 443, app.config.get('https:address') || '::1');
-   }
-}
+    });
+  }
+
+  function handleUnauthorized(req, res, cleanup) {
+    if (app.routers.unauthorized.dispatch(req, res)) return;
+
+    //
+    // Even if it is a 404, act like it is 403
+    //
+    res.writeHead(403);
+    res.end();
+  }
+
+  function handleAuthorized(req, res, cleanup) {
+    if (app.routers.authorized.dispatch(req, res)) return;
+    if (app.routers.unauthorized.dispatch(req, res)) return;
+    res.writeHead(404);
+    res.end();
+  }
+
+  if (app.config.get('http')) {
+    app.servers.http.on('request', workflow);
+    app.servers.http.listen(app.config.get('http:port') || 80, app.config.get('http:address') || '::1');
+  }
+  if (app.config.get('https')) {
+    app.servers.https.on('request', workflow);
+    app.servers.https.listen(app.config.get('https:port') || 443, app.config.get('https:address') || '::1');
+  }
+};

--- a/lib/plugins/localfiles.js
+++ b/lib/plugins/localfiles.js
@@ -1,22 +1,20 @@
-var BufferedStream = require('morestreams').BufferedStream;
-var fs = require('fs');
-var path = require('path');
+var fs = require('fs'),
+    path = require('path'),
+    BufferedStream = require('morestreams').BufferedStream;
 
 exports.attach = function () {
-   var app = this;
-   var basePath = app.config.get('localfiles:path');
+  var app = this,
+      basePath = app.config.get('localfiles:path');
 
-   app.before('build.output', function (err, description, stream, callback) {
-      if (!description.filename) {
-         callback.apply(this, arguments);
-         return;
-      }
+  app.before('build.output', function (err, description, stream, callback) {
+    if (!description.filename) {
+      return callback.apply(this, arguments);
+    }
 
-      var us = stream.pipe(fs.createWriteStream(path.join(basePath, description.filename)));
+    var us = stream.pipe(fs.createWriteStream(path.join(basePath, description.filename)));
 
-      us.on('error', callback);
-      us.on('end', callback);
-
-   });
-}
+    us.on('error', callback);
+    us.on('end', callback);
+  });
+};
 

--- a/lib/plugins/pluggable.js
+++ b/lib/plugins/pluggable.js
@@ -3,37 +3,35 @@ var path = require('path');
 // Simple plugin to load other plugins via config.get('plugins')
 //
 exports.name = 'pluggable';
+
 function fetchPlugin(pluginPath) {
-   try {
-      pluginPath = require.resolve(pluginPath);
-   }
-   catch (e) {
-      pluginPath = path.resolve(__dirname, pluginPath);
-   }
-   return require(pluginPath);
+  try { pluginPath = require.resolve(pluginPath) }
+  catch (e) { pluginPath = path.resolve(__dirname, pluginPath) }
+  return require(pluginPath);
 }
 
 exports.attach = function () {
-   var app = this;
-   //
-   // Grab all of our plugins to load
-   //
-   var plugins = app.config.get('plugins');
-   //
-   // Figure out the type (may vary due to things like optimist's argv)
-   // .use it and any value attached to it
-   //
-   if (Array.isArray(plugins)) {
-      plugins.forEach(function(pluginPath) {
-         app.use(fetchPlugin(pluginPath));
-      });
-   }
-   else if (typeof plugins === 'string') {
-         app.use(fetchPlugin(plugins));
-   }
-   else if (typeof plugins === 'object') {
-      Object.keys(plugins).forEach(function (pluginPath) {
-         app.use(fetchPlugin(pluginPath), plugins[pluginPath]);
-      });
-   }
-}
+  //
+  // Grab all of our plugins to load
+  //
+  var app = this,
+      plugins = app.config.get('plugins');
+
+  //
+  // Figure out the type (may vary due to things like optimist's argv)
+  // .use it and any value attached to it
+  //
+  if (Array.isArray(plugins)) {
+    plugins.forEach(function (pluginPath) {
+      app.use(fetchPlugin(pluginPath));
+    });
+  }
+  else if (typeof plugins === 'string') {
+    app.use(fetchPlugin(plugins));
+  }
+  else if (typeof plugins === 'object') {
+    Object.keys(plugins).forEach(function (pluginPath) {
+      app.use(fetchPlugin(pluginPath), plugins[pluginPath]);
+    });
+  }
+};

--- a/lib/plugins/servers.js
+++ b/lib/plugins/servers.js
@@ -1,21 +1,24 @@
-var http = require('http');
-var https = require('https');
+var http = require('http'),
+    https = require('https');
+
 exports.name = 'servers';
+
 exports.attach = function (options) {
-   var httpServer;
-   var httpsServer;
-   this.servers = {
-      get http() {
-         return httpServer || (httpServer = http.createServer());
-      },
-      set http(value) {
-         httpServer = value;
-      },
-      get https() {
-         return httpsServer || (httpsServer = https.createServer(options.https));
-      },
-      set https(value) {
-         httpsServer = value;
-      }
-   };
-}
+  var httpServer,
+      httpsServer;
+
+  this.servers = {
+    get http() {
+      return httpServer || (httpServer = http.createServer());
+    },
+    set http(value) {
+      httpServer = value;
+    },
+    get https() {
+      return httpsServer || (httpsServer = https.createServer(options.https));
+    },
+    set https(value) {
+      httpsServer = value;
+    }
+  };
+};

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -1,120 +1,135 @@
 //
 // Example server, should be fleshed out
 //
-var zlib = require('zlib');
-var tmp = require('tmp');
-var BufferedStream = require('morestreams').BufferedStream;
-var semver = require('semver');
-var merge = require('merge-recursive');
-var fs = require('fs');
-var BuildBot = require('../buildbot');
+var fs = require('fs'),
+    zlib = require('zlib'),
+    BufferedStream = require('morestreams').BufferedStream,
+    merge = require('merge-recursive'),
+    tmp = require('tmp'),
+    semver = require('semver'),
+    BuildBot = require('../buildbot');
 
 module.exports = function (app, options) {
-   //
-   // Add "env" vars from package.json in module
-   //
-   app.before('build.create', function (bot, next) {
-      bot.before('npm.configure', function (err, spawnOptions, next) {
-         if (err) {
-            next(err, null);
-            return;
-         }
-         var moduledir = spawnOptions.spawnWith.cwd;
-         fs.readFile(moduledir + '/package.json', function (err, body) {
-            if (err) {
-               next(err, null);
-               return;
-            }
-            var pkg = JSON.parse(body + '');
-            merge(spawnOptions.env, pkg.env || {});
-            next(null, spawnOptions);
-         });
-      });
-      next(bot);
-   });
-   //
-   // /build
-   //
-   app.routers.authorized.post('/build', function () {
-      var res = this.res;
-      var req = this.req;
-req.connection.setTimeout(20 * 60 * 1000);
-      var heartbeatTimer = setInterval(req.connection.write.bind(req.connection, ''), 60 * 1000);
-      req.connection.on('close', function () { console.log('REMOVING TIMER'); clearInterval(heartbeatTimer); });
-      var pkg = req.headers['x-package-json'];
-      if (pkg) {
-         try {
-            pkg = JSON.parse(pkg);
-         }
-         catch (e) {
-            res.writeHead(400);
-            res.end(e.message);
-            return;
-         }
+  //
+  // Add "env" vars from package.json in module
+  //
+  app.before('build.create', function (bot, next) {
+    bot.before('npm.configure', function (err, spawnOptions, next) {
+      if (err) {
+        return next(err, null);
       }
-      //
-      // Start unzipping before waiting on tmp directory (still needs to be buffered for BuildBot)
-      //
-      var buff = req.buffered.pipe(zlib.createGunzip()).pipe(new BufferedStream);
-      tmp.dir({dir: app.config.get('directories:tmp')}, function (err, dir) {
+
+      var moduledir = spawnOptions.spawnWith.cwd;
+      fs.readFile(moduledir + '/package.json', function (err, body) {
         if (err) {
-          res.writeHead(400);
-          res.end(err.message);
-          return;
+          return next(err, null);
         }
-        var jobDescription = merge.recursive({}, app.config.get('defaults:package') || {}, {
-          //
-          // Gyp is kinda picky about where it finds node installs
-          //
-          env: {
-//            npm_config_nodedir: app.config.get('node:gypdir') + '/' + requestedVersion
-          },
-//          version: requestedVersion
-        });
+        var pkg = JSON.parse(body + '');
+        merge(spawnOptions.env, pkg.env || {});
+        next(null, spawnOptions);
+      });
+    });
+
+    next(bot);
+  });
+
+  //
+  // /build
+  //
+  app.routers.authorized.post('/build', function () {
+    var res = this.res,
+        req = this.req,
+        heartbeatTimer = setInterval(req.connection.write.bind(req.connection, ''), 60 * 1000),
+        pkg = req.headers['x-package-json'];
+
+    req.connection.setTimeout(20 * 60 * 1000);
+    req.connection.on('close', function () {
+      console.log('REMOVING TIMER');
+      clearInterval(heartbeatTimer);
+    });
+
+    if (pkg) {
+      try {
+        pkg = JSON.parse(pkg);
+      }
+      catch (e) {
+        res.writeHead(400);
+        return res.end(e.message);
+      }
+    }
+
+    //
+    // Start unzipping before waiting on tmp directory (still needs to be buffered for BuildBot)
+    //
+    var buff = req.buffered.pipe(zlib.createGunzip()).pipe(new BufferedStream);
+
+    tmp.dir({dir: app.config.get('directories:tmp')}, function (err, dir) {
+      if (err) {
+        res.writeHead(400);
+        return res.end(err.message);
+      }
+
+      var jobDescription = merge.recursive({}, app.config.get('defaults:package') || {}, {
         //
-        // Stream copy is not sufficient
+        // Gyp is kinda picky about where it finds node installs
         //
-        jobDescription.repository = { type: 'tar-stream', stream: buff, destination: dir };
-        if (pkg) {
-          merge.recursive(jobDescription, pkg);
-        }
-        merge.recursive(jobDescription, app.config.get('spawning'));
-        app.perform('build.create', new BuildBot({
+        env: {
+          // npm_config_nodedir: app.config.get('node:gypdir') + '/' + requestedVersion
+        },
+        // version: requestedVersion
+      });
+      //
+
+      // Stream copy is not sufficient
+      //
+      jobDescription.repository = { type: 'tar-stream', stream: buff, destination: dir };
+
+      if (pkg) {
+        merge.recursive(jobDescription, pkg);
+      }
+
+      merge.recursive(jobDescription, app.config.get('spawning'));
+
+      app.perform(
+        'build.create',
+        new BuildBot({
           versions: app.config.get('versions'),
           defaults: app.config.get('defaults:build')
-        }), function (bot) {
+        }),
+        function (bot) {
           bot.build(jobDescription, function (err, tgz) {
             if (err) {
               res.writeHead(400);
-              err.stream ? err.stream.pipe(res) : res.end(err.message);
-              return;
+              return err.stream ? err.stream.pipe(res) : res.end(err.message);
             }
+
             if (req.params.webhook) {
-               var webhook = request({
-                  url: req.params.webhook,
-                  method: 'POST',
-                  headers: {
-                     "content-type": 'application/tar+gzip'
-                  }
-               }, function (err, webhookRes) {
-                  if (err) {
-                     res.writeHead(500);
-                     res.end(err.message);
-                     return;
-                  }
-                  res.writeHead(webhookRes.statusCode, webhookRes.headers);
-                  webhookRes.pipe(res);
-               });
-               tgz.pipe(webhook);
+              var webhook = request({
+                url: req.params.webhook,
+                method: 'POST',
+                headers: {
+                  "content-type": 'application/tar+gzip'
+                }
+              }, function (err, webhookRes) {
+                if (err) {
+                  res.writeHead(500);
+                  return res.end(err.message);
+                }
+                res.writeHead(webhookRes.statusCode, webhookRes.headers);
+                webhookRes.pipe(res);
+              });
+
+              tgz.pipe(webhook);
             }
             else {
-               res.writeHead(200, {
-                 'content-type': 'application/json'
-               });
-               res.end('"ok"');
+              res.writeHead(200, {
+                'content-type': 'application/json'
+              });
+              res.end('"ok"');
             }
           });
-        });
-      });
-   });
+        }
+      );
+    });
+  });
 };

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "merge-recursive": "0.0.3",
     "morestreams": "~0.1.1",
     "ncp": "~0.2.6",
+    "pkgcloud": "~0.6.0",
     "tar": "~0.1.13",
     "tmp": "0.0.13",
     "semver": "~1.0.14",

--- a/package.json
+++ b/package.json
@@ -16,21 +16,21 @@
   "author": "",
   "license": "BSD",
   "dependencies": {
+    "async": "~0.1.22",
     "checkout": "0.0.0",
+    "chownr": "0.0.1",
+    "director": "~1.1.4",
+    "flatiron": "~0.2.8",
+    "fstream": "~0.1.18",
+    "merge-recursive": "0.0.3",
+    "morestreams": "~0.1.1",
     "ncp": "~0.2.6",
     "tar": "~0.1.13",
-    "uuid-v4": "0.0.2",
-    "chownr": "0.0.1",
-    "morestreams": "~0.1.1",
-    "async": "~0.1.22",
-    "fstream": "~0.1.18",
+    "tmp": "0.0.13",
+    "semver": "~1.0.14",
     "uid-number": "0.0.3",
     "understudy": "~0.1.0",
-    "tmp": "0.0.13",
     "utile": "~0.1.3",
-    "flatiron": "~0.2.8",
-    "director": "~1.1.4",
-    "semver": "~1.0.14",
-    "merge-recursive": "0.0.3"
+    "uuid-v4": "0.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "module-foundry",
   "version": "0.1.0",
   "description": "build bot for npm",
-  "main": "server.js",
+  "main": "lib/index.js",
   "publishConfig": {
     "registry": "http://reg.njitsu.net:5984"
   },


### PR DESCRIPTION
@bmeck Please review. 

First, I want to say the codebase is solid. Really impressed with how well it works once I got it integrated into `nodejitsu/nodejitsu`. This is all mostly minor changes.  
1. _Programmatic usage:_ The entire module was designed around being run from `bin/module-foundry`. I moved most of that code into `lib/index.js` 
2. _Coding style:_ There were 3-space indents all over the place and ton of inconsistencies in general style. This of course leads to a large diff, but most of it is just removing 1-space on a lot of lines.
3. _Updates for pkgcloud@0.6.0:_ The Rackspace providers no longer have `username` and `apiKey` inside of an `auth` property.
